### PR TITLE
Fix derivatives in inverse trig functions

### DIFF
--- a/src/hyperdual.jl
+++ b/src/hyperdual.jl
@@ -258,22 +258,22 @@ function asin(z::Hyper)
   funval = asin(real(z))
   deriv1 = 1.0-real(z)*real(z)
   deriv = 1.0/sqrt(deriv1)
-  hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)+eps1(z)*eps2(z)*(real(z)/deriv1^-1.5))
+  hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)+eps1(z)*eps2(z)*(real(z)/deriv1^1.5))
 end
 
 function acos(z::Hyper)
   funval = acos(real(z))
   deriv1 = 1.0-real(z)*real(z)
   deriv = -1.0/sqrt(deriv1)
-  hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)+eps1(z)*eps2(z)*(-real(z)/deriv1^-1.5))
+  hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)+eps1(z)*eps2(z)*(-real(z)/deriv1^1.5))
 end
 
 function atan(z::Hyper)
   funval = atan(real(z))
   deriv1 = 1.0+real(z)*real(z)
-  deriv = 1.0/sqrt(deriv1)
+  deriv = 1.0/deriv1
   hyper(funval, deriv*eps1(z),deriv*eps2(z),
-    deriv*eps1eps2(z)+eps1(z)*eps2(z)*(-2*real(z)/deriv1*deriv1))
+  	deriv*eps1eps2(z)+eps1(z)*eps2(z)*(-2.0*real(z)/(deriv1*deriv1)))
 end
 
 sqrt(z::Hyper) = z^0.5

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -13,6 +13,8 @@ hd5 = Hyper256(1//1, 10//2, 6//2, 20//5)
 hd6 = hyper128(1.0, 6.0, 3.0, 4.0)
 hd7 = Hyper128(1//1, 10//2, 6//2, 20//5)
 
+hd8 = hyper(1//2, 1, 1, 0)
+
 hdNaN = hyper(0/0)
 
 # Addition and subtraction
@@ -54,6 +56,11 @@ println("\nTesting includes Tim Holy's division performance improvement.")
 @test 1/hd2 == hd2^(-1)
 @test hd3^3 == hd3 * hd3 * hd3
 @test (hd3^3)^(1/3) == hd3
+
+# Transcendentals
+@test asin(sin(hd8)) == hd8
+@test atan(tan(hd8)) == hd8
+@test eps1(acos(hd8)) == -eps1(asin(hd8)) && eps1eps2(acos(hd8)) == -eps1eps2(asin(hd8))
 
 # Mixing types
 @test hd5*hd7 == hd7^2


### PR DESCRIPTION
Fixed bugs in `asin`, `acos`, and `atan` affecting calculations of second derivatives (as well as first derivatives in `atan`). To test, compose these functions with their inverses and check for the identity map.