### PR TITLE
Add operators like in DualNumbers

### DIFF
--- a/src/HyperDualNumbers.jl
+++ b/src/HyperDualNumbers.jl
@@ -19,6 +19,7 @@ module HyperDualNumbers
     hyper128,
     ishyper,
     hyper_show,
+    realpart,
     eps1,
     eps2,
     eps1eps2,

--- a/src/hyperdual.jl
+++ b/src/hyperdual.jl
@@ -20,17 +20,17 @@ Hyper256() = Hyper256(0.0, 0.0, 0.0, 0.0)
 const Hyper128 = Hyper{Float32}
 Hyper128() = Hyper128(0.0, 0.0, 0.0, 0.0)
 
-real(z::Hyper) = z.f0
+realpart(z::Hyper) = z.f0
 eps1(z::Hyper) = z.f1
 eps2(z::Hyper) = z.f2
 eps1eps2(z::Hyper) = z.f12
 
-eps(z::Hyper) = eps(real(z))
+eps(z::Hyper) = eps(realpart(z))
 eps(::Type{Hyper{T}}) where T = eps(T)
-one(z::Hyper) = Hyper(one(real(z)))
+one(z::Hyper) = Hyper(one(realpart(z)))
 one(::Type{Hyper{T}}) where T = Hyper(one(T))
 nan(::Type{Hyper{T}}) where T = nan(one(T))
-isnan(z::Hyper) = isnan(real(z))
+isnan(z::Hyper) = isnan(realpart(z))
 
 convert(::Type{Hyper{T}}, x::Real) where T<:Real =
   Hyper{T}(convert(T, x), convert(T, 0), convert(T, 0), convert(T, 0))
@@ -38,11 +38,11 @@ convert(::Type{Hyper{T}}, x::Real) where T<:Real =
 convert(::Type{Hyper{T}}, z::Hyper{T}) where T<:Real = z
 
 convert(::Type{Hyper{T}}, z::Hyper) where T<:Real =
-  Hyper(convert(T, real(z)), convert(T, eps1(z)), convert(T, eps2(z)),
+  Hyper(convert(T, realpart(z)), convert(T, eps1(z)), convert(T, eps2(z)),
     convert(T, eps1eps2(z)))
 
 convert(::Type{T}, z::Hyper) where T<:Real =
-  ((eps1(z) == 0 && eps2(z) == 0 && eps1eps2(z)) ? convert(T, real(z)) : throw(InexactError()))
+  ((eps1(z) == 0 && eps2(z) == 0 && eps1eps2(z)) ? convert(T, realpart(z)) : throw(InexactError()))
 
 promote_rule(::Type{Hyper{T}}, ::Type{Hyper{S}}, ::Type{Hyper{Q}},
   ::Type{Hyper{P}}) where {T<:Real, S<:Real, Q<:Real, P<:Real} =
@@ -64,12 +64,12 @@ hyper() = Hyper()
 hyper256(s::Float64, t::Float64, q::Float64, p::Float64) = Hyper{Float64}(s, t, q, p)
 hyper256(s::Real, t::Real, q::Real, p::Real) =
   hyper256(Float64(s), Float64(t), Float64(q), Float64(p))
-hyper256(z) = hyper256(real(z), eps1(z), eps2(z), eps1eps2(z))
+hyper256(z) = hyper256(realpart(z), eps1(z), eps2(z), eps1eps2(z))
 
 hyper128(s::Float32, t::Float32, q::Float32, p::Float32) = Hyper{Float32}(s, t, q, p)
 hyper128(s::Real, t::Real, q::Real, p::Real) =
   hyper128(Float32(s), Float32(t), Float32(q), Float32(p))
-hyper128(z) = hyper128(real(z), eps1(z), eps2(z), eps1eps2(z))
+hyper128(z) = hyper128(realpart(z), eps1(z), eps2(z), eps1eps2(z))
 
 ishyper(x::Hyper) = true
 ishyper(x::Number) = false
@@ -77,8 +77,8 @@ ishyper(x::Number) = false
 real_valued(z::Hyper{T}) where T <:Real = (eps1(z) == 0 && eps2(z) == 0 && eps1eps2(z) == 0)
 integer_valued(z::Hyper) = real_valued(z) && integer_valued(real(z))
 
-isfinite(z::Hyper) = isfinite(real(z))
-reim(z::Hyper) = (real(z), eps1(z), eps2(z), eps1eps2(z))
+isfinite(z::Hyper) = isfinite(realpart(z))
+reim(z::Hyper) = (realpart(z), eps1(z), eps2(z), eps1eps2(z))
 
 # No-op?
 conjhyper(z::Hyper) = z
@@ -150,7 +150,7 @@ function read(s::IO, ::Type{Hyper{T}}) where {T<:Real}
 end
 
 function write(s::IO, z::Hyper)
-  write(s, real(z))
+  write(s, realpart(z))
   write(s, eps1(z))
   write(s, eps2(z))
   write(s, eps1eps2(z))
@@ -163,30 +163,30 @@ end
 convert(::Type{Hyper}, z::Hyper) = z
 convert(::Type{Hyper}, x::Real) = hyper(x)
 
-+(z::Hyper, w::Hyper) = hyper(real(z) + real(w), eps1(z) + eps1(w),
++(z::Hyper, w::Hyper) = hyper(realpart(z) + realpart(w), eps1(z) + eps1(w),
   eps2(z) + eps2(w), eps1eps2(z) + eps1eps2(w))
-+(z::Number, w::Hyper) = hyper(z + real(w), eps1(w), eps2(w), eps1eps2(w))
-+(z::Hyper, w::Number) = hyper(real(z) + w, eps1(z), eps2(z), eps1eps2(z))
++(z::Number, w::Hyper) = hyper(z + realpart(w), eps1(w), eps2(w), eps1eps2(w))
++(z::Hyper, w::Number) = hyper(realpart(z) + w, eps1(z), eps2(z), eps1eps2(z))
 
--(z::Hyper) = hyper(-real(z), -eps1(z), -eps2(z), -eps1eps2(z))
--(z::Hyper, w::Hyper) = hyper(real(z) - real(w), eps1(z) - eps1(w),
+-(z::Hyper) = hyper(-realpart(z), -eps1(z), -eps2(z), -eps1eps2(z))
+-(z::Hyper, w::Hyper) = hyper(realpart(z) - realpart(w), eps1(z) - eps1(w),
   eps2(z) - eps2(w), eps1eps2(z) - eps1eps2(w))
--(z::Number, w::Hyper) = hyper(z - real(w), -eps1(w), -eps2(w), -eps1eps2(w))
--(z::Hyper, w::Number) = hyper(real(z) - w, eps1(z), eps2(z), eps1eps2(z))
+-(z::Number, w::Hyper) = hyper(z - realpart(w), -eps1(w), -eps2(w), -eps1eps2(w))
+-(z::Hyper, w::Number) = hyper(realpart(z) - w, eps1(z), eps2(z), eps1eps2(z))
 
-*(x::Bool, z::Hyper) = ifelse(x, z, ifelse(signbit(real(z)) == 0, zero(z), -zero(z)))
+*(x::Bool, z::Hyper) = ifelse(x, z, ifelse(signbit(realpart(z)) == 0, zero(z), -zero(z)))
 *(x::Hyper, z::Bool) = z * x
 
-*(z::Hyper, w::Hyper) = hyper(real(z) * real(w),
-  real(z)*eps1(w)+eps1(z)*real(w), real(z)*eps2(w)+eps2(z)*real(w),
-  real(z)*eps1eps2(w)+eps1(z)*eps2(w)+eps2(z)*eps1(w)+real(w)*eps1eps2(z))
+*(z::Hyper, w::Hyper) = hyper(realpart(z) * realpart(w),
+  realpart(z)*eps1(w)+eps1(z)*realpart(w), realpart(z)*eps2(w)+eps2(z)*realpart(w),
+  realpart(z)*eps1eps2(w)+eps1(z)*eps2(w)+eps2(z)*eps1(w)+realpart(w)*eps1eps2(z))
 
-*(z::Hyper, w::Real) = hyper(real(z) * w, eps1(z)*w, eps2(z)*w, w*eps1eps2(z))
+*(z::Hyper, w::Real) = hyper(realpart(z) * w, eps1(z)*w, eps2(z)*w, w*eps1eps2(z))
 *(z::Number, w::Hyper) = w * z
 
-/(z::Hyper, w::Hyper) = z*(one(real(z))/w)
+/(z::Hyper, w::Hyper) = z*(one(realpart(z))/w)
 function /(z::Number, w::Hyper)
-    invrw = one(z)/real(w)
+    invrw = one(z)/realpart(w)
     deriv = -z*invrw^2
     hyper(z*invrw, eps1(w)*deriv, eps2(w)*deriv,
           eps1eps2(w)*deriv-2eps1(w)*eps2(w)*deriv*invrw)
@@ -195,100 +195,98 @@ end
 # Needed to prevent ambiguous warning:
 #   /(Number,Complex{T<:Real}) at complex.jl:127
 
-/(z::Hyper, w::Complex) = hyper(real(z)/w, eps1(z)/w, eps2(z)/w, eps1eps2(z)/w)
-/(z::Hyper, w::Number) = hyper(real(z)/w, eps1(z)/w, eps2(z)/w, eps1eps2(z)/w)
+/(z::Hyper, w::Complex) = hyper(realpart(z)/w, eps1(z)/w, eps2(z)/w, eps1eps2(z)/w)
+/(z::Hyper, w::Number) = hyper(realpart(z)/w, eps1(z)/w, eps2(z)/w, eps1eps2(z)/w)
 
 abs2(z::Hyper) = z*z
 abs(z::Hyper) = sqrt(abs2(z))                    # Is this correct?
 
-Base.real(z::Hyper) = Hyper(real(real(z)), real(eps1(z)), real(eps2(z)), real(eps1eps2(z)))
-Base.imag(z::Hyper) = Hyper(imag(real(z)), imag(eps1(z)), imag(eps2(z)), imag(eps1eps2(z)))
-Base.conj(z::Hyper) = Hyper(conj(real(z)), conj(eps1(z)), conj(eps2(z)), conj(eps1eps2(z)))
-Base.float(z::Hyper) = Hyper(float(real(z)), float(eps1(z)), float(eps2(z)), float(eps1eps2(z)))
-Base.complex(z::Hyper) = Hyper(complex(real(z)), complex(eps1(z)), complex(eps2(z)), complex(eps1eps2(z)))
+for op in (:real, :imag, :conj, :float, :complex)
+    @eval Base.$op(z::Hyper) = Hyper($op(realpart(z)), $op(eps1(z)), $op(eps2(z)), $op(eps1eps2(z)))
+end
 
 function ^(z::Hyper, w::Rational)
-  deriv = w * real(z)^(w-1)
-  hyper(real(z)^w, eps1(z)*deriv, eps2(z)*deriv,
-    eps1eps2(z)*deriv+w*(w-1)*eps1(z)*eps2(z)*real(z)^(w-2))
+  deriv = w * realpart(z)^(w-1)
+  hyper(realpart(z)^w, eps1(z)*deriv, eps2(z)*deriv,
+    eps1eps2(z)*deriv+w*(w-1)*eps1(z)*eps2(z)*realpart(z)^(w-2))
 end
 
 function ^(z::Hyper, w::Integer)
-  deriv = w * real(z)^(w-1)
-  hyper(real(z)^w, eps1(z)*deriv, eps2(z)*deriv,
-    eps1eps2(z)*deriv+w*(w-1)*eps1(z)*eps2(z)*real(z)^(w-2))
+  deriv = w * realpart(z)^(w-1)
+  hyper(realpart(z)^w, eps1(z)*deriv, eps2(z)*deriv,
+    eps1eps2(z)*deriv+w*(w-1)*eps1(z)*eps2(z)*realpart(z)^(w-2))
 end
 
 function ^(z::Hyper, w::Number)
-  xval = real(z)
+  xval = realpart(z)
   tol = typeof(xval)==AbstractFloat ? eps(xval) : 10.0^-15
   if abs(float(xval)) < tol
     xval = ifelse(signbit(xval)==0, tol, -tol)
   end
   deriv = w * xval^(w-1)
   # Use actual value for f0, tol for deriv only
-  hyper(real(z)^w, eps1(z)*deriv, eps2(z)*deriv,
+  hyper(realpart(z)^w, eps1(z)*deriv, eps2(z)*deriv,
     eps1eps2(z)*deriv+w*(w-1)*eps1(z)*eps2(z)*xval^(w-2))
 end
 
 ^(z::Hyper, w::Hyper) = exp(w*log(z))
 
 function exp(z::Hyper)
-  deriv = exp(real(z))
+  deriv = exp(realpart(z))
   hyper(deriv, deriv*eps1(z), deriv*eps2(z), deriv*(eps1eps2(z)+eps1(z)*eps2(z)))
 end
 
 function log(z::Hyper)
-  deriv1 = eps1(z)/real(z)
-  deriv2 = eps2(z)/real(z)
-  hyper(log(real(z)), deriv1, deriv2, eps1eps2(z)/real(z)-(deriv1*deriv2))
+  deriv1 = eps1(z)/realpart(z)
+  deriv2 = eps2(z)/realpart(z)
+  hyper(log(realpart(z)), deriv1, deriv2, eps1eps2(z)/realpart(z)-(deriv1*deriv2))
 end
 
 function sin(z::Hyper)
-  funval = sin(real(z))
-  deriv = cos(real(z))
+  funval = sin(realpart(z))
+  deriv = cos(realpart(z))
   hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)-funval*eps1(z)*eps2(z))
 end
 
 function cos(z::Hyper)
-  funval = cos(real(z))
-  deriv = -sin(real(z))
+  funval = cos(realpart(z))
+  deriv = -sin(realpart(z))
   hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)-funval*eps1(z)*eps2(z))
 end
 
 function tan(z::Hyper)
-  funval = tan(real(z))
+  funval = tan(realpart(z))
   deriv = funval*funval+1
   hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)+eps1(z)*eps2(z)*(2*funval*deriv))
 end
 
 function asin(z::Hyper)
-  funval = asin(real(z))
-  deriv1 = 1.0-real(z)*real(z)
+  funval = asin(realpart(z))
+  deriv1 = 1.0-realpart(z)*realpart(z)
   deriv = 1.0/sqrt(deriv1)
-  hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)+eps1(z)*eps2(z)*(real(z)/deriv1^1.5))
+  hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)+eps1(z)*eps2(z)*(realpart(z)/deriv1^1.5))
 end
 
 function acos(z::Hyper)
-  funval = acos(real(z))
-  deriv1 = 1.0-real(z)*real(z)
+  funval = acos(realpart(z))
+  deriv1 = 1.0-realpart(z)*realpart(z)
   deriv = -1.0/sqrt(deriv1)
-  hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)+eps1(z)*eps2(z)*(-real(z)/deriv1^1.5))
+  hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)+eps1(z)*eps2(z)*(-realpart(z)/deriv1^1.5))
 end
 
 function erf(z::Hyper)
-  funval = erf(real(z))
-  deriv = 2.0*exp(-1.0*real(z)*real(z))/(sqrt(pi))
-  deriv1 = -2.0*real(z)*deriv;
+  funval = erf(realpart(z))
+  deriv = 2.0*exp(-1.0*realpart(z)*realpart(z))/(sqrt(pi))
+  deriv1 = -2.0*realpart(z)*deriv;
   hyper(funval, deriv*eps1(z),deriv*eps2(z),deriv*eps1eps2(z)+eps1(z)*eps2(z)*deriv1)
 end
 
 function atan(z::Hyper)
-  funval = atan(real(z))
-  deriv1 = 1.0+real(z)*real(z)
+  funval = atan(realpart(z))
+  deriv1 = 1.0+realpart(z)*realpart(z)
   deriv = 1.0/deriv1
   hyper(funval, deriv*eps1(z),deriv*eps2(z),
-    deriv*eps1eps2(z)+eps1(z)*eps2(z)*(-2.0*real(z)/(deriv1*deriv1)))
+    deriv*eps1eps2(z)+eps1(z)*eps2(z)*(-2.0*realpart(z)/(deriv1*deriv1)))
 end
 
 sqrt(z::Hyper) = z^0.5
@@ -301,27 +299,27 @@ minimum(z::Hyper, w::Hyper) = z < w ? z : w
 minimum(z::Hyper, w::Number) = z < w ? z : hyper(w)
 minimum(z::Number, w::Hyper) = z < w ? hyper(z) : w
 
->(z::Hyper, w::Hyper) = real(z) > real(w)
->(z::Hyper, w::Number) = real(z) > w
->(z::Number, w::Hyper) = z > real(w)
->=(z::Hyper, w::Hyper) = real(z) >= real(w)
->=(z::Hyper, w::Number) = real(z) >= w
->=(z::Number, w::Hyper) = z >= real(w)
-<(z::Hyper, w::Hyper) = real(z) < real(w)
-<(z::Hyper, w::Number) = real(z) < w
-<(z::Number, w::Hyper) = z < real(w)
-<=(z::Hyper, w::Hyper) = real(z) <= real(w)
-<=(z::Hyper, w::Number) = real(z) <= w
-<=(z::Number, w::Hyper) = z <= real(w)
+>(z::Hyper, w::Hyper) = realpart(z) > realpart(w)
+>(z::Hyper, w::Number) = realpart(z) > w
+>(z::Number, w::Hyper) = z > realpart(w)
+>=(z::Hyper, w::Hyper) = realpart(z) >= realpart(w)
+>=(z::Hyper, w::Number) = realpart(z) >= w
+>=(z::Number, w::Hyper) = z >= realpart(w)
+<(z::Hyper, w::Hyper) = realpart(z) < realpart(w)
+<(z::Hyper, w::Number) = realpart(z) < w
+<(z::Number, w::Hyper) = z < realpart(w)
+<=(z::Hyper, w::Hyper) = realpart(z) <= realpart(w)
+<=(z::Hyper, w::Number) = realpart(z) <= w
+<=(z::Number, w::Hyper) = z <= realpart(w)
 
 
-==(z::Hyper, w::Hyper) = real(z) == real(w) && eps1(z) == eps1(w) &&
+==(z::Hyper, w::Hyper) = realpart(z) == realpart(w) && eps1(z) == eps1(w) &&
   eps2(z) == eps2(w) && eps1eps2(z) == eps1eps2(w)  
 
-==(z::Hyper, x::Real) = real_valued(z) && real(z) == x
+==(z::Hyper, x::Real) = real_valued(z) && realpart(z) == x
 ==(x::Real, z::Hyper) = ==(z, x)
 
-isequal(z::Hyper, w::Hyper) = isequal(real(z), real(w)) && isequal(eps1(z), eps1(w)) && 
+isequal(z::Hyper, w::Hyper) = isequal(realpart(z), realpart(w)) && isequal(eps1(z), eps1(w)) && 
   isequal(eps2(z), eps2(w)) && isequal(eps1eps2(z), eps1eps2(w))
 
 isequal(z::Hyper, x::Real) = 

--- a/src/hyperdual.jl
+++ b/src/hyperdual.jl
@@ -201,9 +201,11 @@ end
 abs2(z::Hyper) = z*z
 abs(z::Hyper) = sqrt(abs2(z))                    # Is this correct?
 
-for op in (:real, :imag, :conj, :float, :complex)
-    @eval Base.$op(z::Hyper) = Hyper($op(real(z)), $op(eps1(z)), $op(eps2(z)), $op(eps1eps2(z)))
-end
+Base.real(z::Hyper) = Hyper(real(real(z)), real(eps1(z)), real(eps2(z)), real(eps1eps2(z)))
+Base.imag(z::Hyper) = Hyper(imag(real(z)), imag(eps1(z)), imag(eps2(z)), imag(eps1eps2(z)))
+Base.conj(z::Hyper) = Hyper(conj(real(z)), conj(eps1(z)), conj(eps2(z)), conj(eps1eps2(z)))
+Base.float(z::Hyper) = Hyper(float(real(z)), float(eps1(z)), float(eps2(z)), float(eps1eps2(z)))
+Base.complex(z::Hyper) = Hyper(complex(real(z)), complex(eps1(z)), complex(eps2(z)), complex(eps1eps2(z)))
 
 function ^(z::Hyper, w::Rational)
   deriv = w * real(z)^(w-1)

--- a/test/test_Erf_example.jl
+++ b/test/test_Erf_example.jl
@@ -34,10 +34,10 @@ end
 S0 = Hyper(100.0, 1.0, 1.0, 0)
 K=80.0;T=2.0;r=0.01;sigma=0.2;
 Price=blsprice(S0,K,r,T,sigma);
-@test (abs(real(Price)-blsprice(real(S0),K,r,T,sigma))<1e-15)
-@test (abs(eps1(Price)-blsdelta(real(S0),K,r,T,sigma))<1e-15)
-@test (abs(eps1eps2(Price)-blsgamma(real(S0),K,r,T,sigma))<1e-15)
-println("$(real(Price))   = $( blsprice(real(S0),K,r,T,sigma))")
-println("$(eps1(Price))   = $( blsdelta(real(S0),K,r,T,sigma))")
-println("$(eps1eps2(Price))   = $( blsgamma(real(S0),K,r,T,sigma))")
+@test (abs(realpart(Price)-blsprice(realpart(S0),K,r,T,sigma))<1e-15)
+@test (abs(eps1(Price)-blsdelta(realpart(S0),K,r,T,sigma))<1e-15)
+@test (abs(eps1eps2(Price)-blsgamma(realpart(S0),K,r,T,sigma))<1e-15)
+println("$(realpart(Price))   = $( blsprice(realpart(S0),K,r,T,sigma))")
+println("$(eps1(Price))   = $( blsdelta(realpart(S0),K,r,T,sigma))")
+println("$(eps1eps2(Price))   = $( blsgamma(realpart(S0),K,r,T,sigma))")
 println("Test Erf Passed")

--- a/test/test_Paper_example.jl
+++ b/test/test_Paper_example.jl
@@ -28,7 +28,7 @@ println("t8 = ", t8)
 println()
 println("f(t0) = ", f(t0))
 
-@test abs(f(1.5) - real(f(t0))) < 5eps(1.0)
+@test abs(f(1.5) - realpart(f(t0))) < 5eps(1.0)
 @test abs(eps1(f(t0))-4.053427893898621) < 5eps(1.0) && eps1(f(t0)) == eps2(f(t0))
 @test abs(eps1eps2(f(t0))-9.463073681596601) < 5eps(1.0)
 


### PR DESCRIPTION
I had an issue with 
```julia
julia> using HyperDualNumbers

julia> x = hyper(1.0)
Hyper{Float64}(1.0, 0.0, 0.0, 0.0)

julia> x'x
ERROR: MethodError: no method matching conj(::Hyper{Float64})
Closest candidates are:
  conj(::Missing) at missing.jl:79
  conj(::Real) at number.jl:191
  conj(::Complex) at complex.jl:259
  ...
Stacktrace:
 [1] adjoint(::Hyper{Float64}) at ./number.jl:193
 [2] top-level scope at none:0
```
So I thought I would suggest adding the operators as in DualNumbers.