### PR TITLE
Implement complex(::Type{<:Hyper})

### DIFF
--- a/src/hyperdual.jl
+++ b/src/hyperdual.jl
@@ -251,6 +251,7 @@ end
 
 Base.float(h::Union{Hyper{T}, Hyper{Complex{T}}}) where {T<:AbstractFloat} = h
 Base.complex(h::Hyper{<:Complex}) = h
+Base.complex(::Type{Hyper{T}}) where {T} = Hyper{complex(T)}
 
 Base.floor(h::Hyper) = floor(value(h))
 Base.ceil(h::Hyper)  = ceil(value(h))

--- a/test/tests_from_DualNumbers.jl
+++ b/test/tests_from_DualNumbers.jl
@@ -187,6 +187,14 @@ end
         end
     end
 
+    @testset "complex type conversion" begin
+        for T in [Float16, Float32, Float64, BigFloat, Int8, Int16, Int32, Int64, Int128, BigInt, Bool]
+            D = Hyper{T}
+            @test typeof(complex(zero(D))) == complex(D)
+            D = Hyper{Complex{T}}
+            @test typeof(complex(zero(D))) == complex(D)
+        end
+    end
 end
 
 @testset "Check bug in `inv`" begin


### PR DESCRIPTION
This matches the docstring of `complex`. Now

```julia
julia> complex(Hyper128)
Hyper{ComplexF32}

julia> typeof(complex(zero(Hyper128))) == complex(Hyper128)
true
```